### PR TITLE
add(toolbox): support toolbox container lifecycle hooks

### DIFF
--- a/chart/charts/gitlab/charts/toolbox/templates/deployment.yaml
+++ b/chart/charts/gitlab/charts/toolbox/templates/deployment.yaml
@@ -179,6 +179,10 @@ spec:
             {{- include "gitlab.certificates.volumeMount" . | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml .Values.lifecycle | nindent 12 }}
+          {{- end }}
       volumes:
       {{- include "gitlab.extraVolumes" . | nindent 6 }}
       {{- include "gitlab.psql.ssl.volume" . | nindent 6 }}

--- a/chart/charts/gitlab/charts/toolbox/values.yaml
+++ b/chart/charts/gitlab/charts/toolbox/values.yaml
@@ -268,3 +268,11 @@ deployment:
   strategy:
     type: Recreate
     rollingUpdate: null
+
+lifecycle: {}
+# preStop:
+#   exec:
+#     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
+# postStart:
+#   exec:
+#     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]


### PR DESCRIPTION
Add ability to run postStart and preStop commands for the toolbox container. This could be used enable gitlab feature flags using the toolbox container, such as: postStart:
  exec:
    command: ["/bin/sh", "-c", "echo "Feature.enable(:access_token_pagination)" | bundle exec gitlab-rails console"]